### PR TITLE
Unset static AppAuthenticator instance on error

### DIFF
--- a/src/Mozu/Api/Security/AppAuthenticator.php
+++ b/src/Mozu/Api/Security/AppAuthenticator.php
@@ -42,7 +42,7 @@ class AppAuthenticator {
 			try {
 				static::$instance->authenticateApp();
 			} catch(\Exception $exc) {
-				static::$instance == null;
+				static::$instance = null;
 				throw $exc;
 			}
 		}


### PR DESCRIPTION
Using `==` without an assignment or an if() is a no-op. Typo?