### PR TITLE
Don't overwrite $apiError

### DIFF
--- a/src/Mozu/Api/MozuClient.php
+++ b/src/Mozu/Api/MozuClient.php
@@ -256,11 +256,12 @@ class MozuClient {
                 }
                 $this->logger->debug($jsonResponse->errorCode . " : " . (MozuConfig::$throwExceptionOn404 == true));
 
-                if (isset($jsonResponse->message))
+                if (isset($jsonResponse->message)) {
                     $apiError = new ApiException($jsonResponse->message, $statusCode);
-                else
+                }
+                else {
                     $apiError = new ApiException($response->getReasonPhrase().", inspect Mozu\Api\ApiException->items property for more details", $statusCode);
-                $apiError = new ApiException($jsonResponse->message, $statusCode);
+                }
                 if (isset($jsonResponse->additionalErrorData)) {
                     $apiError->setAdditionalErrorData( $jsonResponse->additionalErrorData);
                 }


### PR DESCRIPTION
If there is a check for `$jsonResponse->message`, then `$apiError` shouldn't always be based on it.