### PR TITLE
Restore the original timezone setting after switching over to UTC.

### DIFF
--- a/src/Security/AppAuthenticator.php
+++ b/src/Security/AppAuthenticator.php
@@ -87,6 +87,7 @@ class AppAuthenticator {
 	}
 	
 	private function setRefreshInterval($updateRefreshTokenInterval) {
+		$existingTimezone = date_default_timezone_get();
 		if ($this->refreshInterval == null)
 		{
 			date_default_timezone_set("UTC");
@@ -104,8 +105,9 @@ class AppAuthenticator {
 				->setAccessTokenExpiration($accessTokenExpiration)
 				->setRefreshTokenExpiration($refreshTokenExpiration);
 
-        $this->log->info("Access Token Expiration - " . $this->refreshInterval->getAccessTokenExpiration()->format('Y-m-d H:i:s'));
-        $this->log->info("Refresh Token Expiration - " .$this->refreshInterval->getRefreshTokenExpiration()->format('Y-m-d H:i:s'));
+       	$this->log->info("Access Token Expiration - " . $this->refreshInterval->getAccessTokenExpiration()->format('Y-m-d H:i:s'));
+       	$this->log->info("Refresh Token Expiration - " .$this->refreshInterval->getRefreshTokenExpiration()->format('Y-m-d H:i:s'));
+       	date_default_timezone_set($existingTimezone);
 	}
 	
 	public function getAppClaim() {


### PR DESCRIPTION
Timezones in my application kept getting reset after using the API, this fixes that issue.